### PR TITLE
fix: Update pzserver URLs and devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,10 +7,10 @@
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers-contrib/features/black:2": {},
+		// "ghcr.io/devcontainers/features/github-cli:1": {},
+		// "ghcr.io/devcontainers-contrib/features/black:2": {},
 		"ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {},
-		"ghcr.io/dhoeric/features/act:1": {},
+		// "ghcr.io/dhoeric/features/act:1": {},
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/src/pzserver/communicate.py
+++ b/src/pzserver/communicate.py
@@ -24,8 +24,8 @@ class PzRequests:
     }
     _enviroments = {
         "localhost": "http://localhost/api/",
-        "pz-dev": "https://pz-server-dev.linea.org.br/api/",
-        "pz": "https://pz-server.linea.org.br/api/",
+        "pz-dev": "https://pzserver-dev.linea.org.br/api/",
+        "pz": "https://pzserver.linea.org.br/api/",
     }
 
     def __init__(self, token, host="pz"):


### PR DESCRIPTION
This commit updates the URLs for the pzserver environments to reflect the new domain name. It also comments out some features in the devcontainer configuration.

The changes include:

- Updating the URLs for "pz-dev" and "pz" environments in the `PzRequests` class to use the `pzserver` subdomain.
- Commenting out the `github-cli`, `black`, and `act` features in the `.devcontainer/devcontainer.json` file.